### PR TITLE
replace tagfinder.herokuapp.com references with tagfinder.osm.ch

### DIFF
--- a/OSMTagFinder/web/templates/opensearch.xml
+++ b/OSMTagFinder/web/templates/opensearch.xml
@@ -4,11 +4,11 @@
     <Description>Find OpenStreetMap tags</Description>
     <Tags>OpenStreetMap OSM TagFinder Search Tag Key Value</Tags>
     <Contact>sgwerder@hsr.ch</Contact>
-    <Url type="application/x-suggestions+json" rel="suggestions" template="http://tagfinder.herokuapp.com/ossuggest?query={searchTerms}"/>
-    <Url type="text/html" method="get" template="http://tagfinder.herokuapp.com/search?query={searchTerms}"/>
-	<Url type="application/json" method="get" template="http://tagfinder.herokuapp.com/api/search?query={searchTerms}"/>
-    <Url type="application/opensearchdescription+xml" rel="self" template="http://tagfinder.herokuapp.com/opensearch.xml"/>
-    <Image height="16" width="16" type="image/vnd.microsoft.icon">http://tagfinder.herokuapp.com/favicon.ico</Image>
+    <Url type="application/x-suggestions+json" rel="suggestions" template="https://tagfinder.osm.ch/ossuggest?query={searchTerms}"/>
+    <Url type="text/html" method="get" template="https://tagfinder.osm.ch/search?query={searchTerms}"/>
+	<Url type="application/json" method="get" template="https://tagfinder.osm.ch/api/search?query={searchTerms}"/>
+    <Url type="application/opensearchdescription+xml" rel="self" template="https://tagfinder.osm.ch/opensearch.xml"/>
+    <Image height="16" width="16" type="image/vnd.microsoft.icon">https://tagfinder.osm.ch/favicon.ico</Image>
     <OutputEncoding>UTF-8</OutputEncoding>
     <InputEncoding>UTF-8</InputEncoding>
     <SyndicationRight>open</SyndicationRight>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A search engine for [OpenStreetMap](www.openstreetmap.org) tags. It uses [TagInf
 TagFinder was developed as part of a research project for the [Geometa Lab](http://www.hsr.ch/geometalab) (Prof. S. Keller) of the IFS at the University for Applied Sciences Rapperswil (HSR) end of 2014. 
 The application is written in Python 2.7 and uses the Flask web framework. 
 
-There's a demo prototype at [Heroku](http://tagfinder.herokuapp.com/) (in english and german) including a RESTful API.
+There's a demo prototype at [Heroku](https://tagfinder.osm.ch/) (in english and german) including a RESTful API.
 
 ## Installation
 For installation instructions, see the [the README in the OSMTagFinder


### PR DESCRIPTION
Fixes old references to non-working tagfinder.herokuapp.com in Documentation and Opensearch

Additionally, GitHub at https://github.com/geometalab/OSMTagFinder needs fixing URL in ***About*** section (which currently says _"Web search engine for OpenStreetMap tags similar to taginfo but simpler. [tagfinder.herokuapp.com/](http://tagfinder.herokuapp.com/)"_), but GitHub interface cannot be fixed via PR.